### PR TITLE
Fixes to be able to start the sample code

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -12,13 +12,13 @@ const PORT:string = process.env.PORT||"8000";
 
 //Create redis connection for read.
 const client = redis.createClient({
-  host: '127.0.0.1',
+  host: 'redis-server',
   port: 6379
 });
 
 //Create redis connection for publish.
 const publisher = redis.createClient({
-  host: '127.0.0.1',
+  host: 'redis-server',
   port: 6379
 });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     build: 
       dockerfile: dockerfile
       context: ./workers
-    ports:
-      - "8000-9000:5000"
+    # ports:
+    #   - "18000-19000:5000"
     depends_on:
       - redis-server


### PR DESCRIPTION
The source code provided fails to start as the workers cannot bind to the host port when using scaling. They don't need to bind to a port though.
The URL to redis from the API service was incorrect, or at least on my setup (Docker version 20.10.7, build f0df350 on Mac OS 11.4) the API couldn't reach Redis